### PR TITLE
Add RC2 as a bad cipher, implement dictionary for bad ciphers / algorithims

### DIFF
--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/WeakCipherAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/WeakCipherAnalyzerTest.cs
@@ -118,6 +118,59 @@ class WeakCipherAlgorithm
             VerifyCSharpDiagnostic(test, expected);
         }
 
+        [TestMethod]
+        public void WeakCipherVulnerableRC2()
+        {
+            var test = @"
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+class WeakCipherAlgorithm
+{
+
+        private static byte[] EncryptDataRC2(String inName, String outName, byte[] desKey, byte[] desIV,String Data)
+        {
+            byte[] zeroIV = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+            byte[] key = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0 };
+            // Create a new RC2 object to generate a key 
+            // and initialization vector (IV).
+            RC2 RC2alg = RC2.Create();
+
+            // Create a string to encrypt. 
+            byte[] encrypted;
+
+            ICryptoTransform encryptor = RC2alg.CreateEncryptor(key, zeroIV);
+
+            // Create the streams used for encryption. 
+            using (MemoryStream msEncrypt = new MemoryStream())
+            {
+                using (CryptoStream csEncrypt = new CryptoStream(msEncrypt, encryptor, CryptoStreamMode.Write))
+                {
+                    using (StreamWriter swEncrypt = new StreamWriter(csEncrypt))
+                    {
+
+                        //Write all data to the stream.
+                        swEncrypt.Write(Data);
+                    }
+                    encrypted = msEncrypt.ToArray();
+                    return encrypted;
+                }
+            }
+        }
+}";
+            var expected = new DiagnosticResult
+            {
+                Id = "SG0010",
+                Severity = DiagnosticSeverity.Warning
+            };
+
+            VerifyCSharpDiagnostic(test, expected);
+        }
 
         [TestMethod]
         public void WeakCipherVulnerableDES2()
@@ -173,5 +226,58 @@ private static void EncryptData(String inName, String outName, byte[] desKey, by
             VerifyCSharpDiagnostic(test, expected);
         }
 
+        [TestMethod]
+        public void WeakCipherVulnerableRC2_2()
+        {
+            var test = @"
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+class WeakCipherAlgorithm
+{
+private static void EncryptData(String inName, String outName, byte[] rc2Key, byte[] rc2IV)
+        {
+            //Create the file streams to handle the input and output files.
+            FileStream fin = new FileStream(inName, FileMode.Open, FileAccess.Read);
+            FileStream fout = new FileStream(outName, FileMode.OpenOrCreate, FileAccess.Write);
+            fout.SetLength(0);
+
+            //Create variables to help with read and write. 
+            byte[] bin = new byte[100]; //This is intermediate storage for the encryption. 
+            long rdlen = 0;              //This is the total number of bytes written. 
+            long totlen = fin.Length;    //This is the total length of the input file. 
+            int len;                     //This is the number of bytes to be written at a time.
+
+            RC2 rc2 = new RC2CryptoServiceProvider();
+            CryptoStream encStream = new CryptoStream(fout, des.CreateEncryptor(rc2Key, rc2IV), CryptoStreamMode.Write);
+
+
+            //Read from the input file, then encrypt and write to the output file. 
+            while (rdlen < totlen)
+            {
+                len = fin.Read(bin, 0, 100);
+                encStream.Write(bin, 0, len);
+                rdlen = rdlen + len;
+            }
+
+            encStream.Close();
+            fout.Close();
+            fin.Close();
+        }
+    }
+}";
+            var expected = new DiagnosticResult
+            {
+                Id = "SG0010",
+                Severity = DiagnosticSeverity.Warning
+            };
+
+            VerifyCSharpDiagnostic(test, expected);
+        }
     }
 }

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/Utils/AnalyzerUtil.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/Utils/AnalyzerUtil.cs
@@ -21,6 +21,18 @@ namespace RoslynSecurityGuard.Analyzers
                 description : GetLocalString(localeId + "_Message"));
         }
 
+        public static DiagnosticDescriptor GetDescriptorFromResource(string id, string localeId, DiagnosticSeverity severity, params object[] args)
+        {
+            return new DiagnosticDescriptor(id,
+                GetLocalString(localeId + "_Title"),
+                GetLocalString(localeId + "_Title"),
+                "Security",
+                severity,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://dotnet-security-guard.github.io/rules.htm#" + localeId,
+                description: string.Format(GetLocalString(localeId + "_Message").ToString(),args));
+        }
+
         private static LocalizableString GetLocalString(string id) {
             return new LocalizableResourceString(id, Messages.ResourceManager, typeof(Messages));
         }

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/WeakCipherAnalyzer.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/WeakCipherAnalyzer.cs
@@ -14,7 +14,9 @@ namespace RoslynSecurityGuard.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class WeakCipherAnalyzer : DiagnosticAnalyzer
     {
-                private static DiagnosticDescriptor Rule = AnalyzerUtil.GetDescriptorFromResource("SG0010", typeof(WeakCipherAnalyzer).Name, DiagnosticSeverity.Warning);
+        private static DiagnosticDescriptor Rule = AnalyzerUtil.GetDescriptorFromResource("SG0010", typeof(WeakCipherAnalyzer).Name, DiagnosticSeverity.Warning);
+
+        private static ImmutableArray<string> BadCiphers = ImmutableArray.Create("DES", "RC2");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
 
@@ -31,21 +33,27 @@ namespace RoslynSecurityGuard.Analyzers
             if (node != null)
             {
                 var symbol = ctx.SemanticModel.GetSymbolInfo(node).Symbol;
-                //DES.Create()
-                if (AnalyzerUtil.SymbolMatch(symbol, type: "DES", name: "Create"))
+
+                foreach (string cipher in BadCiphers)
                 {
-                    var diagnostic = Diagnostic.Create(Rule, node.Expression.GetLocation(), "DES");
-                    ctx.ReportDiagnostic(diagnostic);
+                    if (AnalyzerUtil.SymbolMatch(symbol, type: cipher, name: "Create"))
+                    {
+                        var diagnostic = Diagnostic.Create(Rule, node.Expression.GetLocation(), cipher);
+                        ctx.ReportDiagnostic(diagnostic);
+                    }
                 }
             }
             if (node2 != null)
             {
                 var symbol = ctx.SemanticModel.GetSymbolInfo(node2).Symbol;
-                //DES.Create()
-                if (AnalyzerUtil.SymbolMatch(symbol, type: "DESCryptoServiceProvider"))
+
+                foreach (string cipher in BadCiphers)
                 {
-                    var diagnostic = Diagnostic.Create(Rule, node2.GetLocation(), "DES");
-                    ctx.ReportDiagnostic(diagnostic);
+                    if (AnalyzerUtil.SymbolMatch(symbol, type: cipher+"CryptoServiceProvider"))
+                    {
+                        var diagnostic = Diagnostic.Create(Rule, node2.GetLocation(), cipher);
+                        ctx.ReportDiagnostic(diagnostic);
+                    }
                 }
             }
         }

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/WeakHashingAnalyzer.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/WeakHashingAnalyzer.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace RoslynSecurityGuard.Analyzers
@@ -9,33 +10,31 @@ namespace RoslynSecurityGuard.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class WeakHashingAnalyzer : DiagnosticAnalyzer
     {
-        private static DiagnosticDescriptor Rule = AnalyzerUtil.GetDescriptorFromResource("SG0006", typeof(WeakHashingAnalyzer).Name, DiagnosticSeverity.Warning);
+        private static ImmutableDictionary<string, DiagnosticDescriptor> Rules =
+            new Dictionary<string, DiagnosticDescriptor>
+            {
+                { "MD5", AnalyzerUtil.GetDescriptorFromResource("SG0006", typeof(WeakHashingAnalyzer).Name, DiagnosticSeverity.Warning, "MD5") },
+                { "SHA1", AnalyzerUtil.GetDescriptorFromResource("SG0006", typeof(WeakHashingAnalyzer).Name, DiagnosticSeverity.Warning, "SHA1") }
+            }.ToImmutableDictionary();
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => Rules.Values.ToImmutableArray();
 
-        public override void Initialize(AnalysisContext context)
-        {
-            context.RegisterSyntaxNodeAction(VisitSyntaxNode, SyntaxKind.InvocationExpression);
-        }
+        public override void Initialize(AnalysisContext context) => context.RegisterSyntaxNodeAction(VisitSyntaxNode, SyntaxKind.InvocationExpression);
 
         private static void VisitSyntaxNode(SyntaxNodeAnalysisContext ctx)
         {
-
             var node = ctx.Node as InvocationExpressionSyntax;
             if (node == null) return;
 
             var symbol = ctx.SemanticModel.GetSymbolInfo(node).Symbol;
-            //MD5.Create()
-            if (AnalyzerUtil.SymbolMatch(symbol, type: "MD5", name: "Create"))
+
+            foreach (var r in Rules)
             {
-                var diagnostic = Diagnostic.Create(Rule, node.Expression.GetLocation(), "MD5");
-                ctx.ReportDiagnostic(diagnostic);
-            }
-            //SHA1.Create()
-            else if (AnalyzerUtil.SymbolMatch(symbol, type: "SHA1", name: "Create"))
-            {
-                var diagnostic = Diagnostic.Create(Rule, node.Expression.GetLocation(), "SHA1");
-                ctx.ReportDiagnostic(diagnostic);
+                if (AnalyzerUtil.SymbolMatch(symbol, type: r.Key, name: "Create"))
+                {
+                    var diagnostic = Diagnostic.Create(r.Value, node.Expression.GetLocation(), r.Key);
+                    ctx.ReportDiagnostic(diagnostic);
+                }
             }
         }
     }

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Messages.Designer.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Messages.Designer.cs
@@ -62,7 +62,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The dynamic value passed to the command execution should be validate..
+        ///   Looks up a localized string similar to The dynamic value passed to the command execution should be validated..
         /// </summary>
         internal static string CommandInjectionAnalyzer_Message {
             get {
@@ -80,7 +80,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Event validation is disabled. The integrity of client-side control will not be validate on postback..
+        ///   Looks up a localized string similar to Event validation is disabled. The integrity of client-side control will not be validated on postback..
         /// </summary>
         internal static string EnableEventValidationFalse_Message {
             get {
@@ -98,7 +98,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to View state mac is disable. The view state could be altered by an attacker. (This feature cannot be disabled in the recent version of ASP.net).
+        ///   Looks up a localized string similar to View state mac is disabled. The view state could be altered by an attacker. (This feature cannot be disabled in the recent version of ASP.net).
         /// </summary>
         internal static string EnableViewStateMac_Message {
             get {
@@ -116,7 +116,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The dynamic value passed in the SQL query should be validate..
+        ///   Looks up a localized string similar to The dynamic value passed in the SQL query should be validated..
         /// </summary>
         internal static string LinqSqlInjectionAnalyzer_Message {
             get {
@@ -170,7 +170,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Certificate Validation has been disable. The communication could be intercepted..
+        ///   Looks up a localized string similar to Certificate Validation has been disabled. The communication could be intercepted..
         /// </summary>
         internal static string WeakCertificateValidationAnalyzer_Message {
             get {
@@ -179,7 +179,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Certificate Validation has been disable.
+        ///   Looks up a localized string similar to Certificate Validation has been disabled.
         /// </summary>
         internal static string WeakCertificateValidationAnalyzer_Title {
             get {
@@ -188,7 +188,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DES is not considered strong ciphers for modern applications. Currently, NIST recommends the usage of AES block ciphers instead of DES..
+        ///   Looks up a localized string similar to {0} is not considered a strong cipher for modern applications. Currently, NIST recommends the usage of AES block ciphers instead of DES..
         /// </summary>
         internal static string WeakCipherAnalyzer_Message {
             get {
@@ -224,7 +224,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The ECB mode produce the same result for identical blocks (ie: 16 bytes for AES). An attacker could be able to guess the encrypted message. The use of AES in CBC mode with a HMAC is recommended guaranteeing integrity and confidentiality..
+        ///   Looks up a localized string similar to ECB mode will produce the same result for identical blocks (ie: 16 bytes for AES). An attacker could be able to guess the encrypted message. The use of AES in CBC mode with a HMAC is recommended guaranteeing integrity and confidentiality..
         /// </summary>
         internal static string WeakCipherModeAnalyzerEcb_Message {
             get {
@@ -260,7 +260,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The hashing function &quot;{0}&quot; is no longer recommended for password storage and signature generation..
+        ///   Looks up a localized string similar to {0} is no longer considered as strong hashing algorithim for password storage and signature generation..
         /// </summary>
         internal static string WeakHashingAnalyzer_Message {
             get {
@@ -296,7 +296,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The dynamic value passed to the XPath query should be validate.
+        ///   Looks up a localized string similar to The dynamic value passed to the XPath query should be validated.
         /// </summary>
         internal static string XPathInjectionAnalyzer_Message {
             get {
@@ -314,7 +314,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The XML parser is configured incorrectly. The operation could be vulnerable to XXE..
+        ///   Looks up a localized string similar to The XML parser is configured incorrectly. The operation could be vulnerable to XML eXternal Entity (XXE) processing..
         /// </summary>
         internal static string XxeAnalyzer_Message {
             get {

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Messages.Designer.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Messages.Designer.cs
@@ -188,7 +188,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is not considered a strong cipher for modern applications. Currently, NIST recommends the usage of AES block ciphers instead of DES..
+        ///   Looks up a localized string similar to {0} is not considered a strong cipher for modern applications. Currently, NIST recommends the usage of AES block ciphers instead of {0}..
         /// </summary>
         internal static string WeakCipherAnalyzer_Message {
             get {
@@ -260,7 +260,7 @@ namespace RoslynSecurityGuard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is no longer considered as strong hashing algorithim for password storage and signature generation..
+        ///   Looks up a localized string similar to {0} is no longer considered a strong hashing algorithim for password storage and signature generation..
         /// </summary>
         internal static string WeakHashingAnalyzer_Message {
             get {

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Messages.resx
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Messages.resx
@@ -160,7 +160,7 @@
     <value>Certificate Validation has been disabled</value>
   </data>
   <data name="WeakCipherAnalyzer_Message" xml:space="preserve">
-    <value>DES is not considered a strong cipher for modern applications. Currently, NIST recommends the usage of AES block ciphers instead of DES.</value>
+    <value>{0} is not considered a strong cipher for modern applications. Currently, NIST recommends the usage of AES block ciphers instead of DES.</value>
   </data>
   <data name="WeakCipherAnalyzer_Title" xml:space="preserve">
     <value>Weak cipher algorithm</value>
@@ -184,7 +184,7 @@
     <value>Weak cipher mode</value>
   </data>
   <data name="WeakHashingAnalyzer_Message" xml:space="preserve">
-    <value>The hashing function "{0}" is no longer recommended for password storage and signature generation.</value>
+    <value>{0} is no longer considered as strong hashing algorithim for password storage and signature generation.</value>
   </data>
   <data name="WeakHashingAnalyzer_Title" xml:space="preserve">
     <value>Weak hashing function</value>

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Messages.resx
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Messages.resx
@@ -160,7 +160,7 @@
     <value>Certificate Validation has been disabled</value>
   </data>
   <data name="WeakCipherAnalyzer_Message" xml:space="preserve">
-    <value>{0} is not considered a strong cipher for modern applications. Currently, NIST recommends the usage of AES block ciphers instead of DES.</value>
+    <value>{0} is not considered a strong cipher for modern applications. Currently, NIST recommends the usage of AES block ciphers instead of {0}.</value>
   </data>
   <data name="WeakCipherAnalyzer_Title" xml:space="preserve">
     <value>Weak cipher algorithm</value>
@@ -184,7 +184,7 @@
     <value>Weak cipher mode</value>
   </data>
   <data name="WeakHashingAnalyzer_Message" xml:space="preserve">
-    <value>{0} is no longer considered as strong hashing algorithim for password storage and signature generation.</value>
+    <value>{0} is no longer considered a strong hashing algorithim for password storage and signature generation.</value>
   </data>
   <data name="WeakHashingAnalyzer_Title" xml:space="preserve">
     <value>Weak hashing function</value>


### PR DESCRIPTION
Just some minor changes to allow the arbitrary addition of more ciphers and algorithms which are considered bad.

Also fixed a bug where the string formatter ({0}) from the messages.resx was getting rendered in the extension