### PR TITLE
Hotfix for issue #20

### DIFF
--- a/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/Taint/ExecutionState.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/Taint/ExecutionState.cs
@@ -22,7 +22,7 @@ namespace RoslynSecurityGuard.Analyzers.Taint
         }
 
         public void AddNewValue(string identifier, VariableState value) {
-            Variables.Add(identifier, value);
+            if (!Variables.ContainsKey(identifier)) Variables.Add(identifier, value);
         }
 
         public VariableState GetValueByIdentifier(string identifier) {


### PR DESCRIPTION
The application crashed while testing the SqlCommand injection analysis on a large document I made. I realised that, for a document containing multiple errors with variables having the same identifier, a crash would occur during the analysis. It is caused by adding multiple identical keys to a dictionnary. 

With this fix, the application behavior seems to be the same (all tests are passing) and I can scan large files containing multiple variables having the same identifier

