### PR TITLE
Feature xss prevention analyzer

### DIFF
--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/RoslynSecurityGuard.Test.csproj
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/RoslynSecurityGuard.Test.csproj
@@ -141,6 +141,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Tests\XssPreventionAnalyzerTest.cs" />
     <Compile Include="Tests\CsrfTokenAnalyzerTest.cs" />
     <Compile Include="Tests\CsrfTokenCodeFixProviderTest.cs" />
     <Compile Include="Tests\HardcodedPasswordTest.cs" />

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/XssPreventionAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/XssPreventionAnalyzerTest.cs
@@ -1,0 +1,146 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoslynSecurityGuard.Analyzers;
+using System.Collections.Generic;
+using System.Web.Mvc;
+using TestHelper;
+
+namespace RoslynSecurityGuard.Test.Tests
+{
+    [TestClass]
+    public class XssPreventionAnalyzerTest : DiagnosticVerifier
+    {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        {
+            return new XssPreventionAnalyzer();
+        }
+        
+        protected override IEnumerable<MetadataReference> GetAdditionnalReferences()
+        {
+            return new[] { MetadataReference.CreateFromFile(typeof(ValidateAntiForgeryTokenAttribute).Assembly.Location) };
+        }
+        
+        [TestMethod]
+        public void unencodedSensibleData()
+        {
+            var test = @"
+            using Microsoft.AspNetCore.Mvc;
+            using System.Text.Encodings.Web;
+
+            namespace VulnerableApp
+            {
+                public class TestController : Controller
+                {
+                    [HttpGet(""{sensibleData}"")]
+                    public string Get(int sensibleData)
+                    {
+                        return ""value "" + sensibleData;
+                    }
+                }
+            }
+            ";
+            var expected = new DiagnosticResult
+            {
+                Id = "SG1111",
+                Severity = DiagnosticSeverity.Warning
+            };
+
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [TestMethod]
+        public void encodedSensibleDataWithTemporaryVariable()
+        {
+            var test = @"
+            using Microsoft.AspNetCore.Mvc;
+            using System.Text.Encodings.Web;
+
+            namespace VulnerableApp
+            {
+                public class TestController : Controller
+                {
+                    [HttpGet(""{sensibleData}"")]
+                    public string Get(string sensibleData)
+                    {
+                        string temporary_variable = HtmlEncoder.Default.Encode(sensibleData);
+                        return ""value "" + temporary_variable;
+                    }
+                }
+            }
+            ";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void encodedSensibleDataOnReturn()
+        {
+            var test = @"
+            using Microsoft.AspNetCore.Mvc;
+            using System.Text.Encodings.Web;
+
+            namespace VulnerableApp
+            {
+                public class TestController : Controller
+                {
+                    [HttpGet(""{sensibleData}"")]
+                    public string Get(string sensibleData)
+                    {
+                        return ""value "" + HtmlEncoder.Default.Encode(sensibleData);
+                    }
+                }
+            }
+            ";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void returnEncodedData()
+        {
+            var test = @"
+            using Microsoft.AspNetCore.Mvc;
+            using System.Text.Encodings.Web;
+
+            namespace VulnerableApp
+            {
+                public class TestController : Controller
+                {
+                    [HttpGet(""{sensibleData}"")]
+                    public string Get(string sensibleData)
+                    {
+                        return HtmlEncoder.Default.Encode(""value "" + sensibleData);
+                    }
+                }
+            }
+            ";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void encodedDataWithSameVariableUsage()
+        {
+            var test = @"
+            using Microsoft.AspNetCore.Mvc;
+            using System.Text.Encodings.Web;
+
+            namespace VulnerableApp
+            {
+                public class TestController : Controller
+                {
+                    [HttpGet(""{sensibleData}"")]
+                    public string Get(string sensibleData)
+                    {
+                        sensibleData = HtmlEncoder.Default.Encode(""value "" + sensibleData);
+                        return ""value "" + HtmlEncoder.Default.Encode(sensibleData);
+                    }
+                }
+            }
+            ";
+
+            VerifyCSharpDiagnostic(test);
+        }
+    }
+}

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/XssPreventionAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/XssPreventionAnalyzerTest.cs
@@ -42,7 +42,7 @@ namespace RoslynSecurityGuard.Test.Tests
             ";
             var expected = new DiagnosticResult
             {
-                Id = "SG1111",
+                Id = "SG0025",
                 Severity = DiagnosticSeverity.Warning
             };
 

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/XssPreventionAnalyzer.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/XssPreventionAnalyzer.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Immutable;
+using RoslynSecurityGuard.Analyzers.Locale;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections;
+
+namespace RoslynSecurityGuard.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class XssPreventionAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "SG1111";
+
+        private List<string> encodingMethods = new List<string>() { "HtmlEncoder.Default.Encode", "HttpContext.Server.HtmlEncode" };
+
+        private static DiagnosticDescriptor Rule = LocaleUtil.GetDescriptor(DiagnosticId);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(VisitMethods, SyntaxKind.ClassDeclaration);
+        }
+
+        private void VisitMethods(SyntaxNodeAnalysisContext ctx)
+        {
+            ClassDeclarationSyntax node = ctx.Node as ClassDeclarationSyntax;
+
+            if (node == null) return;
+
+            // Ensures that the analyzed class has a dependency to Controller
+            if (node.DescendantNodesAndSelf()
+                .OfType<BaseListSyntax>()
+                .Where(childrenNode => childrenNode.ToString().Contains("Controller"))
+                .Count()
+                .Equals(0))
+            { return; }
+
+            IEnumerable<MethodDeclarationSyntax> methodsWithParameters = node.DescendantNodesAndSelf()
+                .OfType<MethodDeclarationSyntax>()
+                .Where(method => !method.ParameterList.Parameters.Count().Equals(0));
+
+            foreach (MethodDeclarationSyntax method in methodsWithParameters)
+            {
+                SyntaxList<StatementSyntax> methodStatements = method.Body.Statements;
+                IEnumerable<InvocationExpressionSyntax> methodInvocations = method.DescendantNodes().OfType<InvocationExpressionSyntax>();
+
+                if (!methodStatements.Count().Equals(0))
+                {
+                    DataFlowAnalysis flow = ctx.SemanticModel.AnalyzeDataFlow(methodStatements.First(), methodStatements.Last());
+
+                    // Returns from the Data Flow Analysis of sensible data 
+                    // Sensible data is: Data passed as a parameter that is also returned as is by the method
+                    IEnumerable<ISymbol> sensibleVariables = flow.DataFlowsIn.Union(flow.VariablesDeclared.Except(flow.AlwaysAssigned))
+                                                                .Union(flow.WrittenInside)
+                                                                .Intersect(flow.WrittenOutside);
+                                          
+                    // Ensures that the sensible data does not have any encoding
+                    if (!sensibleVariables.Count().Equals(0))
+                    {
+                        foreach (ISymbol sensibleVariable in sensibleVariables)
+                        {
+                            bool sensibleVariableIsEncoded = false;
+                            foreach (InvocationExpressionSyntax methodInvocation in methodInvocations)
+                            {
+                                SeparatedSyntaxList<ArgumentSyntax> arguments = methodInvocation.ArgumentList.Arguments;
+                                if (!arguments.Count().Equals(0))
+                                {
+                                    if (arguments.First().ToString().Contains(sensibleVariable.Name.ToString()))
+                                    {
+                                        sensibleVariableIsEncoded = true;
+                                    }
+                                }
+                            }
+
+                            if (!sensibleVariableIsEncoded)
+                            {
+                                ctx.ReportDiagnostic(Diagnostic.Create(Rule, method.GetLocation()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/XssPreventionAnalyzer.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/XssPreventionAnalyzer.cs
@@ -16,7 +16,7 @@ namespace RoslynSecurityGuard.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class XssPreventionAnalyzer : DiagnosticAnalyzer
     {
-        public const string DiagnosticId = "SG1111";
+        public const string DiagnosticId = "SG0025";
 
         private List<string> encodingMethods = new List<string>() { "HtmlEncoder.Default.Encode", "HttpContext.Server.HtmlEncode" };
 

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Messages.yml
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Messages.yml
@@ -53,6 +53,12 @@ SG0009:
   title: The cookie is missing security flag HttpOnly
   description: It is recommended to specify the HttpOnly flag to new cookie.
 
+# XSS
+SG1111:
+  class: XssAnalyzer
+  title: Endpoint method shows an XSS vulnerability
+  description: The endpoint uses a variables from client input and the value isn't encoded.
+
 #Crypto
 
 SG0005:

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Messages.yml
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Messages.yml
@@ -53,12 +53,6 @@ SG0009:
   title: The cookie is missing security flag HttpOnly
   description: It is recommended to specify the HttpOnly flag to new cookie.
 
-# XSS
-SG1111:
-  class: XssAnalyzer
-  title: Endpoint method shows an XSS vulnerability
-  description: The endpoint uses a variables from client input and the value isn't encoded.
-
 #Crypto
 
 SG0005:
@@ -137,3 +131,9 @@ SG0024:
   class: EnableViewStateMac
   title: View state mac is disabled (Future)
   description: View state mac is disabled. The view state could be altered by an attacker. (This feature cannot be disabled in the recent version of ASP.net)
+
+# XSS
+SG0025:
+  class: XssAnalyzer
+  title: Endpoint method shows an XSS vulnerability
+  description: The endpoint returns a variable from the client input that has not been encoded.

--- a/RoslynSecurityGuard/RoslynSecurityGuard/RoslynSecurityGuard.csproj
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/RoslynSecurityGuard.csproj
@@ -65,6 +65,7 @@
       <DependentUpon>Empty.resx</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Analyzers\XssPreventionAnalyzer.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Empty.resx">


### PR DESCRIPTION
Rule to prevent, as much as possible, XSS in endpoints.

Rule:
1. Retrieve all the classes that are inheriting from the controller class
2. Retrieve all the methods from this class that are using parameters
3. Retrieve the sensible data from the method with the DataFlowAnalysis
4. Validate that the sensible variables are encoded with a list comparison.

If they are not, a diagnostic is created.