### PR TITLE
fix/DefiningAttributesInOneLine #38

### DIFF
--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/CsrfTokenAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/CsrfTokenAnalyzerTest.cs
@@ -26,23 +26,23 @@ namespace RoslynSecurityGuard.Test.Tests
         public void CsrfDetectMissingToken()
         {
             var test = @"
-using System;
-using System.Diagnostics;
-using System.Web.Mvc;
+                using System;
+                using System.Diagnostics;
+                using System.Web.Mvc;
 
-namespace VulnerableApp
-{
-    public class TestController
-    {
-        [HttpPost]
-        //[ValidateAntiForgeryToken]
-        public ActionResult ControllerMethod(string input) {
+                namespace VulnerableApp
+                {
+                    public class TestController
+                    {
+                        [HttpPost]
+                        //[ValidateAntiForgeryToken]
+                        public ActionResult ControllerMethod(string input) {
 
-            return null;
-        }
-    }
-}
-";
+                            return null;
+                        }
+                    }
+                }
+                ";
             var expected = new DiagnosticResult
             {
                 Id = "SG0016",
@@ -57,34 +57,48 @@ namespace VulnerableApp
         public void CsrfValidateAntiForgeryTokenPresent()
         {
             var test = @"
-using System;
-using System.Diagnostics;
-using System.Web.Mvc;
+                using System;
+                using System.Diagnostics;
+                using System.Web.Mvc;
 
-namespace VulnerableApp
-{
-    public class TestController
-    {
-        [HttpPost]
-        [ValidateAntiForgeryToken]
-        public ActionResult ControllerMethod(string input) {
+                namespace VulnerableApp
+                {
+                    public class TestController
+                    {
+                        [HttpPost]
+                        [ValidateAntiForgeryToken]
+                        public ActionResult ControllerMethod(string input) {
 
-            return null;
-        }
-    }
-}
-";
+                            return null;
+                        }
+                    }
+                }
+                ";
 
             VerifyCSharpDiagnostic(test);
         }
 
-        
-        [HttpPost]
-        [ValidateAntiForgeryToken]
-        public ActionResult ControllerMethod(string input) {
+        [TestMethod]
+        public void CsrfValidateAntiForgeryTokenPresentWithInlinedAttributes()
+        {
+            var test = @"
+                using System;
+                using System.Diagnostics;
+                using System.Web.Mvc;
 
-            return null;
+                namespace VulnerableApp
+                {
+                    public class TestController
+                    {
+                        [HttpPost, ValidateAntiForgeryToken]
+                        public ActionResult ControllerMethod(string input) {
+                            return null;
+                        }
+                    }
+                }
+                ";
+
+            VerifyCSharpDiagnostic(test);
         }
-        
     }
 }


### PR DESCRIPTION
Fix for issue #38 

In CsrfTokenAnalyzer:
 - Creates a list of all the attributes of a method then ensures the secure attributes presence.

The behavior for an inlined list of attributes was not the same as for multiple lined attributes.