### PR TITLE
Introduction of taint analysis extension #41

### DIFF
--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -37,7 +37,7 @@ namespace TestHelper
         /// <param name="language">The language the source classes are in</param>
         /// <param name="analyzer">The analyzer to be run on the sources</param>
         /// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
-        private static Diagnostic[] GetSortedDiagnostics(string[] sources, string language, ImmutableArray<DiagnosticAnalyzer> analyzers, IEnumerable<MetadataReference> references = null)
+        private static Diagnostic[] GetSortedDiagnostics(string[] sources, string language, List<DiagnosticAnalyzer> analyzers, IEnumerable<MetadataReference> references = null)
         {
             return GetSortedDiagnosticsFromDocuments(analyzers, GetDocuments(sources, language, references));
         }
@@ -49,7 +49,7 @@ namespace TestHelper
         /// <param name="analyzer">The analyzer to run on the documents</param>
         /// <param name="documents">The Documents that the analyzer will be run on</param>
         /// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
-        protected static Diagnostic[] GetSortedDiagnosticsFromDocuments(ImmutableArray<DiagnosticAnalyzer> analyzers, Document[] documents)
+        protected static Diagnostic[] GetSortedDiagnosticsFromDocuments(List<DiagnosticAnalyzer> analyzers, Document[] documents)
         {
             var projects = new HashSet<Project>();
             foreach (var document in documents)
@@ -60,7 +60,7 @@ namespace TestHelper
             var diagnostics = new List<Diagnostic>();
             foreach (var project in projects)
             {
-                var compilationWithAnalyzers = project.GetCompilationAsync().Result.WithAnalyzers(analyzers);
+                var compilationWithAnalyzers = project.GetCompilationAsync().Result.WithAnalyzers(ImmutableArray.Create(analyzers.ToArray()));
                 var diags = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
                 foreach (var diag in diags)
                 {

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/RoslynSecurityGuard.Test.csproj
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/RoslynSecurityGuard.Test.csproj
@@ -141,10 +141,12 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Tests\Password\HardcodedPasswordFieldTest.cs" />
+    <Compile Include="Tests\Password\SqlCredentialTest.cs" />
     <Compile Include="Tests\XssPreventionAnalyzerTest.cs" />
     <Compile Include="Tests\CsrfTokenAnalyzerTest.cs" />
     <Compile Include="Tests\CsrfTokenCodeFixProviderTest.cs" />
-    <Compile Include="Tests\HardcodedPasswordTest.cs" />
+    <Compile Include="Tests\Password\HardcodedPasswordTest.cs" />
     <Compile Include="Tests\InsecureCookieAnalyzerTest.cs" />
     <Compile Include="Tests\InsecureCookieCodeFixProviderTest.cs" />
     <Compile Include="Tests\OutputCacheAnnotationAnalyzerTest.cs" />

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/CsrfTokenAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/CsrfTokenAnalyzerTest.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RoslynSecurityGuard.Analyzers;
-using RoslynSecurityGuard.Analyzers.Taint;
 using System.Collections.Generic;
 using System.Web.Mvc;
 using TestHelper;
@@ -12,9 +11,9 @@ namespace RoslynSecurityGuard.Test.Tests
     [TestClass]
     public class CsrfTokenAnalyzerTest : DiagnosticVerifier
     {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new CsrfTokenAnalyzer();
+            return new [] { new CsrfTokenAnalyzer() };
         }
         
         protected override IEnumerable<MetadataReference> GetAdditionnalReferences()

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/CsrfTokenCodeFixProviderTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/CsrfTokenCodeFixProviderTest.cs
@@ -21,9 +21,9 @@ namespace RoslynSecurityGuard.Test.Tests
             return new[] { MetadataReference.CreateFromFile(typeof(ValidateAntiForgeryTokenAttribute).Assembly.Location) };
         }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new CsrfTokenAnalyzer();
+            return new[] { new CsrfTokenAnalyzer() };
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/InsecureCookieAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/InsecureCookieAnalyzerTest.cs
@@ -7,6 +7,7 @@ using TestHelper;
 using Microsoft.CodeAnalysis.Diagnostics;
 using RoslynSecurityGuard.Analyzers;
 using Microsoft.CodeAnalysis;
+using RoslynSecurityGuard.Analyzers.Taint;
 
 namespace RoslynSecurityGuard.Test.Tests
 {
@@ -14,14 +15,14 @@ namespace RoslynSecurityGuard.Test.Tests
     public class InsecureCookieAnalyzerTest : DiagnosticVerifier
     {
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new InsecureCookieAnalyzer();
+            return new DiagnosticAnalyzer[] { new TaintAnalyzer(), new InsecureCookieAnalyzer() };
         }
 
         protected override IEnumerable<MetadataReference> GetAdditionnalReferences()
         {
-            return new[] { MetadataReference.CreateFromFile(typeof(HttpCookie).Assembly.Location)};
+            return new[] { MetadataReference.CreateFromFile(typeof(HttpCookie).Assembly.Location) };
         }
 
         [TestMethod]
@@ -44,7 +45,8 @@ namespace VulnerableApp
 }
 ";
 
-            var expected08 = new DiagnosticResult {
+            var expected08 = new DiagnosticResult
+            {
                 Id = "SG0008",
                 Severity = DiagnosticSeverity.Warning
             };
@@ -78,6 +80,7 @@ namespace VulnerableApp
 ";
             VerifyCSharpDiagnostic(test);
         }
+
 /*
         static void TestCookie()
         {

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/InsecureCookieCodeFixProviderTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/InsecureCookieCodeFixProviderTest.cs
@@ -10,6 +10,7 @@ using RoslynSecurityGuard.Analyzers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.CodeAnalysis;
 using System.Web;
+using RoslynSecurityGuard.Analyzers.Taint;
 
 namespace RoslynSecurityGuard.Test.Tests
 {
@@ -22,9 +23,9 @@ namespace RoslynSecurityGuard.Test.Tests
             return new[] { MetadataReference.CreateFromFile(typeof(HttpCookie).Assembly.Location) };
         }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new InsecureCookieAnalyzer();
+            return new DiagnosticAnalyzer[] { new TaintAnalyzer(), new InsecureCookieAnalyzer() };
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/OutputCacheAnnotationAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/OutputCacheAnnotationAnalyzerTest.cs
@@ -13,9 +13,9 @@ namespace RoslynSecurityGuard.Test.Tests
     [TestClass]
     public class OutputCacheAnnotationAnalyzerTest : DiagnosticVerifier
     {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new OutputCacheAnnotationAnalyzer();
+            return new[] { new OutputCacheAnnotationAnalyzer() };
         }
         
         protected override IEnumerable<MetadataReference> GetAdditionnalReferences()

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Password/HardcodedPasswordFieldTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Password/HardcodedPasswordFieldTest.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoslynSecurityGuard.Analyzers;
+using RoslynSecurityGuard.Analyzers.Taint;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Security;
+using TestHelper;
+
+namespace RoslynSecurityGuard.Test.Tests
+{
+    [TestClass]
+    public class HardcodedPasswordFieldTest : DiagnosticVerifier
+    {
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            return new DiagnosticAnalyzer[] { new TaintAnalyzer(), new UnknownPasswordApiAnalyzer() };
+        }
+
+        [TestMethod]
+        public void HardCodePasswordDerivedBytes()
+        {
+
+            var test = @"
+using System;
+
+namespace VulnerableApp
+{
+    class HardCodedPassword
+    {
+        static void TestCookie()
+        {
+            var uri = new UriBuilder();
+            uri.Password = ""t0ps3cr3t"";
+        }
+    }
+}
+";
+
+            var expected = new DiagnosticResult
+            {
+                Id = "SG0015",
+                Severity = DiagnosticSeverity.Warning
+            };
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+        public void sandbox()
+        {
+            var uri = new UriBuilder();
+            uri.Password = "t0ps3cr3t";
+        }
+    }
+}

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Password/HardcodedPasswordTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Password/HardcodedPasswordTest.cs
@@ -13,9 +13,9 @@ namespace RoslynSecurityGuard.Tests
     public class HardcodedPasswordTest : DiagnosticVerifier
     {
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new TaintAnalyzer();
+            return new[] { new TaintAnalyzer() };
         }
 
         protected override IEnumerable<MetadataReference> GetAdditionnalReferences()
@@ -36,7 +36,7 @@ namespace VulnerableApp
 {
     class HardCodedPassword
     {
-        static void TestCookie()
+        static void TestHardcodedValue()
         {
             var test = new PasswordDeriveBytes(""hardcode"", new byte[] { 0, 1, 2, 3 });
         }
@@ -65,7 +65,7 @@ namespace VulnerableApp
 {
     class HardCodedPassword
     {
-        static void TestCookie(string input)
+        static void TestHardcodedValue(string input)
         {
             var test = new PasswordDeriveBytes(input, new byte[] { 0, 1, 2, 3 });
         }

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Password/SqlCredentialTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Password/SqlCredentialTest.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoslynSecurityGuard.Analyzers.Taint;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Security;
+using TestHelper;
+
+namespace RoslynSecurityGuard.Test.Tests.Password
+{
+    [TestClass]
+    public class SqlCredentialTest : DiagnosticVerifier
+    {
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            return new[] { new TaintAnalyzer() };
+        }
+
+
+        public void sandbox()
+        {
+            SecureString sec = new SecureString();
+            string pwd = "abc123";
+            pwd.ToCharArray().ToList().ForEach(c => sec.AppendChar(c));
+            /* and now : seal the deal */
+            sec.MakeReadOnly();
+
+            SqlCredential cred = new SqlCredential("test", sec);
+        }
+    }
+}

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/RequestValidationAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/RequestValidationAnalyzerTest.cs
@@ -2,7 +2,7 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RoslynSecurityGuard.Analyzers;
-
+using System.Collections.Generic;
 using System.Web.Mvc;
 using TestHelper;
 
@@ -11,9 +11,9 @@ namespace RoslynSecurityGuard.Test.Tests
     [TestClass]
     public class RequestValidationAnalyzerTest : DiagnosticVerifier
     {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new RequestValidationAnalyzer();
+            return new[] { new RequestValidationAnalyzer() };
         }
         
         [TestMethod]

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Taint/CommandInjectionAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Taint/CommandInjectionAnalyzerTest.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RoslynSecurityGuard.Analyzers;
 using RoslynSecurityGuard.Analyzers.Taint;
+using System.Collections.Generic;
 using System.Diagnostics;
 using TestHelper;
 
@@ -13,9 +14,9 @@ namespace RoslynSecurityGuard.Tests
     public class CommandInjectionAnalyzerTest : DiagnosticVerifier
     {
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new TaintAnalyzer();
+            return new[] { new TaintAnalyzer() };
         }
 
         //No diagnostics expected to show up

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Taint/LinqSqlInjectionAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Taint/LinqSqlInjectionAnalyzerTest.cs
@@ -13,9 +13,9 @@ namespace RoslynSecurityGuard.Tests
     public class LinqSqlInjectionAnalyzerTest : DiagnosticVerifier
     {
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new TaintAnalyzer();
+            return new[] { new TaintAnalyzer() };
         }
 
         protected override IEnumerable<MetadataReference> GetAdditionnalReferences()

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Taint/PathTraversalAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Taint/PathTraversalAnalyzerTest.cs
@@ -16,9 +16,9 @@ namespace RoslynSecurityGuard.Test.Tests.Taint
     public class PathTraversalAnalyzerTest : DiagnosticVerifier
     {
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new TaintAnalyzer();
+            return new[] { new TaintAnalyzer() };
         }
 
         protected override IEnumerable<MetadataReference> GetAdditionnalReferences()

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Taint/TaintAnalyzerControlFlowTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Taint/TaintAnalyzerControlFlowTest.cs
@@ -15,9 +15,9 @@ namespace RoslynSecurityGuard.Test.Tests
     public class TaintAnalyzerControlFlowTest : DiagnosticVerifier
     {
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new TaintAnalyzer();
+            return new[] { new TaintAnalyzer() };
         }
 
 

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Taint/TaintAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Taint/TaintAnalyzerTest.cs
@@ -12,9 +12,9 @@ namespace RoslynSecurityGuard.Tests
     public class TaintAnalyzerTest : DiagnosticVerifier
     {
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new TaintAnalyzer();
+            return new List<DiagnosticAnalyzer> { new TaintAnalyzer() };
         }
 
 

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Taint/XPathInjectionAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/Taint/XPathInjectionAnalyzerTest.cs
@@ -14,9 +14,9 @@ namespace RoslynSecurityGuard.Tests
     {
 
         
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new TaintAnalyzer();
+            return new[] { new TaintAnalyzer() };
         }
 
         protected override IEnumerable<MetadataReference> GetAdditionnalReferences()

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/WeakCertificateValidationAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/WeakCertificateValidationAnalyzerTest.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RoslynSecurityGuard.Analyzers;
 using System;
+using System.Collections.Generic;
 using TestHelper;
 
 namespace RoslynSecurityGuard.Tests
@@ -11,9 +12,9 @@ namespace RoslynSecurityGuard.Tests
     public class WeakCertificateValidationAnalyzerTest : DiagnosticVerifier
     {
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new WeakCertificateValidationAnalyzer();
+            return new[] { new WeakCertificateValidationAnalyzer() };
         }
 
         [TestMethod]

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/WeakCipherAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/WeakCipherAnalyzerTest.cs
@@ -14,9 +14,9 @@ namespace RoslynSecurityGuard.Test.Tests
     [TestClass]
     public class WeakCipherAnalyzerTest : DiagnosticVerifier
     {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new WeakCipherAnalyzer();
+            return new[] { new WeakCipherAnalyzer() };
         }
 
         [TestMethod]

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/WeakCipherModeAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/WeakCipherModeAnalyzerTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RoslynSecurityGuard.Analyzers;
+using System.Collections.Generic;
 using TestHelper;
 
 namespace RoslynSecurityGuard.Test.Tests
@@ -10,9 +11,9 @@ namespace RoslynSecurityGuard.Test.Tests
     public class WeakCipherModeAnalyzerTest : DiagnosticVerifier
     {
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new WeakCipherModeAnalyzer();
+            return new[] { new WeakCipherModeAnalyzer() };
         }
 
         [TestMethod]

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/WeakHashingAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/WeakHashingAnalyzerTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RoslynSecurityGuard.Analyzers;
+using System.Collections.Generic;
 using TestHelper;
 
 namespace RoslynSecurityGuard.Tests
@@ -10,9 +11,9 @@ namespace RoslynSecurityGuard.Tests
     public class WeakHashingAnalyzerTest : DiagnosticVerifier
     {
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new WeakHashingAnalyzer();
+            return new[] { new WeakHashingAnalyzer() };
         }
 
         [TestMethod]

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/WeakRandomAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/WeakRandomAnalyzerTest.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RoslynSecurityGuard.Analyzers;
 using System;
+using System.Collections.Generic;
 using TestHelper;
 
 namespace RoslynSecurityGuard.Tests
@@ -10,9 +11,9 @@ namespace RoslynSecurityGuard.Tests
     [TestClass]
     public class WeakRandomAnalyzerTest : DiagnosticVerifier
     {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new WeakRandomAnalyzer();
+            return new[] { new WeakRandomAnalyzer() };
         }
 
         [TestMethod]

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/XssPreventionAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/XssPreventionAnalyzerTest.cs
@@ -11,9 +11,9 @@ namespace RoslynSecurityGuard.Test.Tests
     [TestClass]
     public class XssPreventionAnalyzerTest : DiagnosticVerifier
     {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new XssPreventionAnalyzer();
+            return new[] { new XssPreventionAnalyzer() };
         }
         
         protected override IEnumerable<MetadataReference> GetAdditionnalReferences()

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/XssPreventionAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/XssPreventionAnalyzerTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RoslynSecurityGuard.Analyzers;
+using System.Collections.Generic;
 using TestHelper;
 
 namespace RoslynSecurityGuard.Test.Tests

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/XxeAnalyzerTest.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Tests/XxeAnalyzerTest.cs
@@ -11,9 +11,9 @@ namespace RoslynSecurityGuard.Tests
     [TestClass]
     public class XxeAnalyzerTest : DiagnosticVerifier
     {
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new XxeAnalyzer();
+            return new [] { new XxeAnalyzer() };
         }
 
         protected override IEnumerable<MetadataReference> GetAdditionnalReferences()

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Verifiers/CodeFixVerifier.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Verifiers/CodeFixVerifier.cs
@@ -53,7 +53,12 @@ namespace TestHelper
             //Console.WriteLine("== New source (START) ==");
             //Console.WriteLine(normalizeNew);
             //Console.WriteLine("== New source (END) ==");
-            VerifyFix(LanguageNames.CSharp, ImmutableArray.Create(GetCSharpDiagnosticAnalyzers(), new DebugAnalyzer()), GetCSharpCodeFixProvider(), normalizeOld, normalizeNew, codeFixIndex, allowNewCompilerDiagnostics);
+
+
+            var a = GetCSharpDiagnosticAnalyzers().ToList();
+            a.Add(new DebugAnalyzer());
+
+            VerifyFix(LanguageNames.CSharp, a, GetCSharpCodeFixProvider(), normalizeOld, normalizeNew, codeFixIndex, allowNewCompilerDiagnostics);
         }
 
         /// <summary>
@@ -69,7 +74,7 @@ namespace TestHelper
         /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
         /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
         /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
-        private void VerifyFix(string language, ImmutableArray<DiagnosticAnalyzer> analyzers, CodeFixProvider codeFixProvider, string oldSource, string newSource, int? codeFixIndex, bool allowNewCompilerDiagnostics)
+        private void VerifyFix(string language, List<DiagnosticAnalyzer> analyzers, CodeFixProvider codeFixProvider, string oldSource, string newSource, int? codeFixIndex, bool allowNewCompilerDiagnostics)
         {
             var document = CreateDocument(oldSource, language, GetAdditionnalReferences());
             var analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(analyzers, new[] { document });

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Test/Verifiers/DiagnosticVerifier.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Test/Verifiers/DiagnosticVerifier.cs
@@ -21,7 +21,8 @@ namespace TestHelper
         /// <summary>
         /// Get the CSharp analyzer being tested - to be implemented in non-abstract class
         /// </summary>
-        protected abstract DiagnosticAnalyzer GetCSharpDiagnosticAnalyzers();
+        protected abstract IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers();
+
         protected virtual IEnumerable<MetadataReference> GetAdditionnalReferences() {
             return null;
         }
@@ -37,7 +38,10 @@ namespace TestHelper
         /// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
         protected void VerifyCSharpDiagnostic(string source, params DiagnosticResult[] expected)
         {
-            VerifyDiagnostics(new[] { source }, LanguageNames.CSharp, ImmutableArray.Create(GetCSharpDiagnosticAnalyzers(),new DebugAnalyzer()), expected);
+
+            var a = GetCSharpDiagnosticAnalyzers().ToList();
+            a.Add(new DebugAnalyzer());
+            VerifyDiagnostics(new[] { source }, LanguageNames.CSharp, a, expected);
         }
 
         [TestInitialize]
@@ -54,7 +58,7 @@ namespace TestHelper
         /// <param name="language">The language of the classes represented by the source strings</param>
         /// <param name="analyzer">The analyzer to be run on the source code</param>
         /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-        private void VerifyDiagnostics(string[] sources, string language, ImmutableArray<DiagnosticAnalyzer> analyzers, params DiagnosticResult[] expected)
+        private void VerifyDiagnostics(string[] sources, string language, List<DiagnosticAnalyzer> analyzers, params DiagnosticResult[] expected)
         {
             var diagnostics = GetSortedDiagnostics(sources, language, analyzers, GetAdditionnalReferences());
             VerifyDiagnosticResults(diagnostics, analyzers, expected);
@@ -68,9 +72,9 @@ namespace TestHelper
         /// Diagnostics are considered equal only if the DiagnosticResultLocation, Id, Severity, and Message of the DiagnosticResult match the actual diagnostic.
         /// </summary>
         /// <param name="actualResults">The Diagnostics found by the compiler after running the analyzer on the source code</param>
-        /// <param name="analyzer">The analyzer that was being run on the sources</param>
+        /// <param name="analyzers">The analyzers that was being run on the sources</param>
         /// <param name="expectedResults">Diagnostic Results that should have appeared in the code</param>
-        private static void VerifyDiagnosticResults(IEnumerable<Diagnostic> actualResults, ImmutableArray<DiagnosticAnalyzer> analyzers, params DiagnosticResult[] expectedResults)
+        private static void VerifyDiagnosticResults(IEnumerable<Diagnostic> actualResults, List<DiagnosticAnalyzer> analyzers, params DiagnosticResult[] expectedResults)
         {
             int expectedCount = expectedResults.Count();
             int actualCount = actualResults.Count();

--- a/RoslynSecurityGuard/RoslynSecurityGuard.Vsix/source.extension.vsixmanifest
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="RoslynSecurityGuard..45fa56c2-16f1-4395-8c10-a5a460084018" Version="2.0.0" Language="en-US" Publisher="Philippe Arteau"/>
+    <Identity Id="RoslynSecurityGuard..45fa56c2-16f1-4395-8c10-a5a460084018" Version="2.2.0" Language="en-US" Publisher="Philippe Arteau"/>
     <DisplayName>Roslyn Security Guard</DisplayName>
     <Description xml:space="preserve">Roslyn analyzers that aim to help security audit on .NET applications.</Description>
     <MoreInfo>https://github.com/dotnet-security-guard/roslyn-security-guard</MoreInfo>

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/InsecureCookieAnalyzer.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/InsecureCookieAnalyzer.cs
@@ -15,7 +15,7 @@ using RoslynSecurityGuard.Analyzers.Locale;
 namespace RoslynSecurityGuard.Analyzers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class InsecureCookieAnalyzer : DiagnosticAnalyzer
+    public class InsecureCookieAnalyzer : DiagnosticAnalyzer, TaintAnalyzerExtension
     {
         public const string DiagnosticIdSecure = "SG0008";
         private static DiagnosticDescriptor RuleSecure = LocaleUtil.GetDescriptor(DiagnosticIdSecure);
@@ -24,92 +24,107 @@ namespace RoslynSecurityGuard.Analyzers
         private static DiagnosticDescriptor RuleHttpOnly = LocaleUtil.GetDescriptor(DiagnosticIdHttpOnly);
         
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(RuleSecure,RuleHttpOnly);
-        
-        public override void Initialize(AnalysisContext context)
-        {
 
-            context.RegisterSyntaxNodeAction(VisitMethods, SyntaxKind.MethodDeclaration);
+        public InsecureCookieAnalyzer() {
+            TaintAnalyzer.RegisterExtension(this);
         }
 
-        private void VisitMethods(SyntaxNodeAnalysisContext ctx)
+        public override void Initialize(AnalysisContext context)
         {
-            var node = ctx.Node as MethodDeclarationSyntax;
+            
+        }
 
-            if (node == null) { //Not the expected node type
-                return;
+        public void VisitStatement(StatementSyntax statement, ExecutionState state)
+        {
+            var localDeclaration = statement as LocalDeclarationStatementSyntax;
+            if (localDeclaration == null) return;
+            var varDeclaration = localDeclaration.Declaration as VariableDeclarationSyntax;
+            if (varDeclaration == null) return;
+
+            foreach (var variable in varDeclaration.Variables)
+            {
+
+                //Looking for the creation of a cookie (HttpCookie)
+
+                var variableDecorator = variable as VariableDeclaratorSyntax;
+                if (variableDecorator != null)
+                {
+                    var expressionValue = variableDecorator.Initializer?.Value;
+                    if (expressionValue is ObjectCreationExpressionSyntax)
+                    {
+                        var objCreation = (ObjectCreationExpressionSyntax)expressionValue;
+
+                        var symbol = state.GetSymbol(objCreation);
+                        if (AnalyzerUtil.SymbolMatch(symbol, "HttpCookie", ".ctor"))
+                        {
+                            //It will override the initial state
+                            state.AddNewValue(variableDecorator.Identifier.Text, //
+                                new VariableState(VariableTaint.SAFE) //
+                                    .AddTag(VariableTag.HttpCookie) //
+                                    .AddSyntaxNode(variable));
+                        }
+                    }
+                }
             }
+            
+        }
 
-            var state = new ExecutionState(ctx);
 
-            VisitNodeRecursively(node, state);
+        public void VisitInvocationAndCreation(ExpressionSyntax node, ArgumentListSyntax argList, ExecutionState state)
+        {
+            
+        }
 
+
+        public void VisitAssignment(AssignmentExpressionSyntax node, ExecutionState state, MethodBehavior behavior, ISymbol symbol, VariableState variableRightState)
+        {
+
+            //Looking for Assigment to Secure or HttpOnly property
+            var assigment = node;
+
+            if (assigment.Left is MemberAccessExpressionSyntax)
+            {
+                var memberAccess = (MemberAccessExpressionSyntax)assigment.Left;
+
+                if (memberAccess.Expression is IdentifierNameSyntax)
+                {
+                    var identifier = (IdentifierNameSyntax)memberAccess.Expression;
+                    string variableAccess = identifier.Identifier.ValueText;
+                    
+                    if (AnalyzerUtil.SymbolMatch(symbol, "HttpCookie", "Secure"))
+                    {
+                        state.AddTag(variableAccess, VariableTag.HttpCookieSecure);
+                    }
+                    else if (AnalyzerUtil.SymbolMatch(symbol, "HttpCookie", "HttpOnly"))
+                    {
+                        state.AddTag(variableAccess, VariableTag.HttpCookieHttpOnly);
+                    }
+                }
+            }
+        }
+
+        public void VisitBeginMethodDeclaration(MethodDeclarationSyntax node, ExecutionState state)
+        {
+            
+        }
+
+        public void VisitEndMethodDeclaration(MethodDeclarationSyntax node, ExecutionState state)
+        {
             //Assert that HttpCookie were configured
-            foreach (var variableState in state.Variables) {
+            foreach (var variableState in state.Variables)
+            {
                 var st = variableState.Value;
                 if (st.tags.Contains(VariableTag.HttpCookie))
                 {
                     if (!st.tags.Contains(VariableTag.HttpCookieSecure))
                     {
-                        ctx.ReportDiagnostic(Diagnostic.Create(RuleSecure, st.node.GetLocation()));
+                        state.AnalysisContext.ReportDiagnostic(Diagnostic.Create(RuleSecure, st.node.GetLocation()));
                     }
                     if (!st.tags.Contains(VariableTag.HttpCookieHttpOnly))
                     {
-                        ctx.ReportDiagnostic(Diagnostic.Create(RuleHttpOnly, st.node.GetLocation()));
+                        state.AnalysisContext.ReportDiagnostic(Diagnostic.Create(RuleHttpOnly, st.node.GetLocation()));
                     }
                 }
-            }
-        }
-
-        private void VisitNodeRecursively(SyntaxNode node, ExecutionState state)
-        {
-            //Looking for the creation of a cookie (HttpCookie)
-            if (node is VariableDeclaratorSyntax)
-            {
-                var variableDecorator = (VariableDeclaratorSyntax)node;
-                var expressionValue = variableDecorator.Initializer?.Value;
-                if (expressionValue is ObjectCreationExpressionSyntax)
-                {
-                    var objCreation = (ObjectCreationExpressionSyntax)expressionValue;
-
-                    var symbol = state.GetSymbol(objCreation);
-                    if (AnalyzerUtil.SymbolMatch(symbol, "HttpCookie", ".ctor"))
-                    {
-                        state.AddNewValue(variableDecorator.Identifier.Text, //
-                            new VariableState(VariableTaint.SAFE) //
-                                .AddTag(VariableTag.HttpCookie) //
-                                .AddSyntaxNode(node));
-                    }
-                }
-            }
-            //Looking for Assigment to Secure or HttpOnly property
-            else if (node is AssignmentExpressionSyntax)
-            {
-                var assigment = (AssignmentExpressionSyntax)node;
-
-                if (assigment.Left is MemberAccessExpressionSyntax) {
-                    var memberAccess = (MemberAccessExpressionSyntax)assigment.Left;
-
-                    if (memberAccess.Expression is IdentifierNameSyntax)
-                    {
-                        var identifier = (IdentifierNameSyntax)memberAccess.Expression;
-                        string variableAccess = identifier.Identifier.ValueText;
-
-                        var symbol = state.GetSymbol(memberAccess);
-                        if (AnalyzerUtil.SymbolMatch(symbol, "HttpCookie", "Secure"))
-                        {
-                            state.AddTag(variableAccess, VariableTag.HttpCookieSecure);
-                        }
-                        else if (AnalyzerUtil.SymbolMatch(symbol, "HttpCookie", "HttpOnly"))
-                        {
-                            state.AddTag(variableAccess, VariableTag.HttpCookieHttpOnly);
-                        }
-                    }
-                }
-            }
-
-            foreach (var n in node.ChildNodes())
-            {
-                VisitNodeRecursively(n,state);
             }
         }
 

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/Locale/LocaleUtil.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/Locale/LocaleUtil.cs
@@ -14,6 +14,8 @@ namespace RoslynSecurityGuard.Analyzers.Locale
 
         public static DiagnosticDescriptor GetDescriptor(string id, string[] args = null)
         {
+
+
             var localTitle = GetLocalString(id + "_Title");
             var localDesc = GetLocalString(id + "_Description");
             return new DiagnosticDescriptor(id,

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/Taint/MethodBehavior.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/Taint/MethodBehavior.cs
@@ -10,12 +10,20 @@ namespace RoslynSecurityGuard.Analyzers.Taint
     {
         public int[] injectablesArguments { get; }
         public int[] passwordArguments { get; }
-        public string vulnerabilityLocale { get; }
+        public string localeInjection { get; }
+        public string localePassword { get; }
+        public bool isInjectableField { get; }
+        public bool isPasswordField { get; }
         
-        public MethodBehavior(int[] injectablesArguments, int[] passwordArguments, string vulnerabilityLocale) {
+        public MethodBehavior(int[] injectablesArguments, int[] passwordArguments, string localeInjection, string localePassword, 
+            bool isInjectableField, bool isPasswordField) {
+
             this.injectablesArguments = injectablesArguments;
             this.passwordArguments = passwordArguments;
-            this.vulnerabilityLocale = vulnerabilityLocale;
+            this.localeInjection = localeInjection;
+            this.localePassword = localePassword;
+            this.isInjectableField = isInjectableField;
+            this.isPasswordField = isPasswordField;
         }
 
 

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/Taint/TaintAnalyzerExtension.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/Taint/TaintAnalyzerExtension.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RoslynSecurityGuard.Analyzers.Taint
+{
+    public interface TaintAnalyzerExtension
+    {
+
+        void VisitStatement(StatementSyntax node, ExecutionState state);
+
+        void VisitInvocationAndCreation(ExpressionSyntax node, ArgumentListSyntax argList, ExecutionState state);
+
+        void VisitAssignment(AssignmentExpressionSyntax node, ExecutionState state, MethodBehavior behavior, ISymbol symbol, VariableState variableRightState);
+
+
+
+        void VisitBeginMethodDeclaration(MethodDeclarationSyntax node, ExecutionState state);
+
+        void VisitEndMethodDeclaration(MethodDeclarationSyntax node, ExecutionState state);
+
+
+   }
+}

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/UnknownPasswordApiAnalyzer.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/UnknownPasswordApiAnalyzer.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using RoslynSecurityGuard.Analyzers.Locale;
+using RoslynSecurityGuard.Analyzers.Taint;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynSecurityGuard.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class UnknownPasswordApiAnalyzer : DiagnosticAnalyzer, TaintAnalyzerExtension
+    {
+
+        private static DiagnosticDescriptor Rule = LocaleUtil.GetDescriptor("SG0015");
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        private List<string> PasswordKeywords = new List<string> {"password", "motdepasse", "heslo", "adgangskode", "wachtwoord", "salasana", "passwort", "passord",
+            "senha","geslo", "clave", "losenord", "clave", "parola", "secretkey", "pwd"};
+
+        public override void Initialize(AnalysisContext context)
+        {
+            TaintAnalyzer.RegisterExtension(this);
+        }
+
+
+        public void VisitAssignment(AssignmentExpressionSyntax node, ExecutionState state, MethodBehavior behavior, ISymbol symbol, VariableState variableRightState)
+        {
+            if (behavior == null && //Unknown API
+                    (symbol != null && IsPasswordField(symbol)) &&
+                    variableRightState.taint == VariableTaint.CONSTANT //Only constant
+                    )
+            {
+                var diagnostic = Diagnostic.Create(Rule, node.GetLocation());
+                state.AnalysisContext.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        public void VisitInvocationAndCreation(ExpressionSyntax node, ArgumentListSyntax argList, ExecutionState state)
+        {
+
+        }
+
+        public void VisitBeginMethodDeclaration(MethodDeclarationSyntax node, ExecutionState state)
+        {
+
+        }
+        
+        public void VisitStatement(StatementSyntax node, ExecutionState state)
+        {
+
+        }
+
+        public void VisitEndMethodDeclaration(MethodDeclarationSyntax node, ExecutionState state)
+        {
+
+        }
+
+        private bool IsPasswordField(ISymbol symbol)
+        {
+            return PasswordKeywords.Contains(symbol.MetadataName.ToLower());
+            //return symbol.MetadataName.ToLower().Contains("password");
+        }
+
+    }
+}

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/XssPreventionAnalyzer.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/XssPreventionAnalyzer.cs
@@ -13,7 +13,7 @@ using System.Collections;
 
 namespace RoslynSecurityGuard.Analyzers
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    //[DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class XssPreventionAnalyzer : DiagnosticAnalyzer
     {
         public const string DiagnosticId = "SG0029";

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Diagnostic.nuspec
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Diagnostic.nuspec
@@ -2,18 +2,18 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>RoslynSecurityGuard</id>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <title>Roslyn Security Guard</title>
     <authors>Security Guard Team</authors>
     <owners>Philippe Arteau</owners>
     <licenseUrl>https://opensource.org/licenses/lgpl-3.0.html</licenseUrl>
     <projectUrl>https://dotnet-security-guard.github.io/</projectUrl>
-    <iconUrl>https://dotnet-security-guard.github.io/images/logo-small.png</iconUrl>
+    <iconUrl>https://avatars3.githubusercontent.com/u/12215494?v=3&amp;s=200</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>RoslynSecurityGuard</description>
-    <releaseNotes>This is the first release of the project Roslyn Security Guard. 14 analyzers for security issues are provided.</releaseNotes>
+    <description>Roslyn analyzers that aim to help security audits on .NET applications.</description>
+    <releaseNotes>This release introduce improved taint analysis. It also brings new code fixes.</releaseNotes>
     <copyright>Copyright Philippe Arteau</copyright>
-    <tags>security,vulnerability,guard</tags>
+    <tags>security,vulnerability,guard,owasp,injection,xss,csrf</tags>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Passwords.yml
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Passwords.yml
@@ -4,15 +4,7 @@
   member: method
   name: .ctor
   passwordArguments: 0
-  locale: SG0015
-
-SecureString:
-  namespace: System.Security
-  className: SecureString
-  member: method
-  name: .ctor
-  passwordArguments: 0
-  locale: SG0015
+  localePass: SG0015
 
 NetworkCredential:
   namespace: System.Net
@@ -20,4 +12,4 @@ NetworkCredential:
   member: method
   name: .ctor
   passwordArguments: 1
-  locale: SG0015
+  localePass: SG0015

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Properties/AssemblyInfo.cs
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Properties/AssemblyInfo.cs
@@ -1,14 +1,15 @@
-﻿using System.Reflection;
+﻿using System.Resources;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("RoslynSecurityGuard")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyTitle("Roslyn Security Guard")]
+[assembly: AssemblyDescription("Analyzers that aim to help security audits on .NET applications.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("RoslynSecurityGuard")]
+[assembly: AssemblyCompany("https://github.com/dotnet-security-guard")]
+[assembly: AssemblyProduct("Roslyn Security Guard")]
 [assembly: AssemblyCopyright("Copyright ©  2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -27,5 +28,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.2.*")]
+[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: NeutralResourcesLanguage("en")]
+

--- a/RoslynSecurityGuard/RoslynSecurityGuard/RoslynSecurityGuard.csproj
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/RoslynSecurityGuard.csproj
@@ -37,7 +37,9 @@
     <Compile Include="Analyzers\Locale\LocaleDiagnostic.cs" />
     <Compile Include="Analyzers\RequestValidationAnalyzer.cs" />
     <Compile Include="Analyzers\OutputCacheAnnotationAnalyzer.cs" />
+    <Compile Include="Analyzers\Taint\TaintAnalyzerExtension.cs" />
     <Compile Include="Analyzers\Taint\VariableTag.cs" />
+    <Compile Include="Analyzers\UnknownPasswordApiAnalyzer.cs" />
     <Compile Include="Analyzers\Utils\AnalyzerUtil.cs" />
     <Compile Include="Analyzers\DebugAnalyzer.cs" />
     <Compile Include="Analyzers\Taint\ExecutionState.cs" />
@@ -74,6 +76,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Behavior.yml" />
     <None Include="Diagnostic.nuspec">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/RoslynSecurityGuard/RoslynSecurityGuard/Sinks.yml
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Sinks.yml
@@ -11,6 +11,7 @@
 #   argTypes: (Optional field) [Parameter types signature]
 #   injectableArguments : (Optional field) [Index of the argument for injectable query, starting from the left]
 #   passwordArguments : (Optional field) [Index of the argument for password parameter, starting from the left]
+#   
 #   locale: [Id of a localization in Messages.yml, This value can be reused for multiple sinks]
 # <<<
 
@@ -29,7 +30,7 @@ sqlcommand_field:
   className: SqlCommand
   member: field
   name: CommandText
-  injectableArguments: 0
+  injectableField: true
   locale: SG0026
 
 dbcommand_field:
@@ -37,7 +38,7 @@ dbcommand_field:
   className: DbCommand
   member: field
   name: CommandText
-  injectableArguments: 0
+  injectableField: true
   locale: SG0026
 
 oledbcommand_constructor:
@@ -107,7 +108,7 @@ sqldatasource_field:
   className: SqlDataSource
   member: field
   name: SelectCommand
-  injectableArguments: 0
+  injectableField: true
   locale: SG0014
 
 sqldatasourceview_field:
@@ -115,7 +116,7 @@ sqldatasourceview_field:
   className: SqlDataSourceView
   member: field
   name: SelectCommand
-  injectableArguments: 0
+  injectableField: true
   locale: SG0014
 
 # Microsoft.Whos.Framework.Data
@@ -143,7 +144,7 @@ systemdiagnostic_process_filename:
   className: ProcessStartInfo
   member: field
   name: FileName
-  injectableArguments: 0
+  injectableField: true
   locale: SG0001
 
 systemdiagnostic_process_arguments:
@@ -151,7 +152,7 @@ systemdiagnostic_process_arguments:
   className: ProcessStartInfo
   member: field
   name: Arguments
-  injectableArguments: 0
+  injectableField: true
   locale: SG0001
 
  #XPath


### PR DESCRIPTION
## What's new?
This PR introduces extensions to the taint analysis.
Extension will be able to hook into the symbolic execution and add tag of their own to variable states.

## Why?
This avoid overloading the responsibility of the taint analyzer and it avoids that every analyzer implement some sort of variable tracking.

## Additional notes
 - The extension also implements DiagnosticAnalyzer (aside from the new TaintAnalysisExtension). This will probably be handy to a developer who wants to disable some rules.
 - Some code cleanup are to be expected. Documentation needs to be added to the interface TaintAnalysisExtension for example.

## Code review needed
@dotnet-security-guard/developers I would like to get opinions on this change. If you don't want or don't have the time to review it, please look specifically at the first extension [InsecureCookieAnalyzer.cs](https://github.com/dotnet-security-guard/roslyn-security-guard/blob/1e6895f31c0b26b03104031739968138608fba73/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/InsecureCookieAnalyzer.cs) and [UnknownPasswordApiAnalyzer.cs](https://github.com/dotnet-security-guard/roslyn-security-guard/blob/1e6895f31c0b26b03104031739968138608fba73/RoslynSecurityGuard/RoslynSecurityGuard/Analyzers/UnknownPasswordApiAnalyzer.cs). It should give you an idea of the template of most of the new rules.