### PR TITLE
Typo in rule SG0017 description

### DIFF
--- a/RoslynSecurityGuard/RoslynSecurityGuard/Config/Messages.yml
+++ b/RoslynSecurityGuard/RoslynSecurityGuard/Config/Messages.yml
@@ -122,8 +122,8 @@ SG0016:
 
 SG0017:
   class: RequestValidationDisableAnalyzer
-  title: Request validation is disable
-  description: Request validation is disable. Request validation allow the filtering of some XSS patterns submitted to the application.
+  title: Request validation is disabled
+  description: Request validation is disabled. Request validation allows the filtering of some XSS patterns submitted to the application.
 
 SG0018:
   class: TaintAnalyzer


### PR DESCRIPTION
I haven't renamed the class but the typo is in there too.

The added newline at the end isn't me, it's github's web interface...