### PR TITLE
Implementation of the PasswordValidator's limit on the RequiredLength

### DIFF
--- a/RoslynSecurityGuard.Test/RoslynSecurityGuard.Test.csproj
+++ b/RoslynSecurityGuard.Test/RoslynSecurityGuard.Test.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -37,6 +37,9 @@
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
@@ -144,6 +147,7 @@
     <Compile Include="Tests\Password\HardcodedPasswordFieldTest.cs" />
     <Compile Include="Tests\Password\SqlCredentialTest.cs" />
     <Compile Include="Tests\Taint\TaintTransferTest.cs" />
+    <Compile Include="Tests\WeakPasswordValidatorAnalyzerTest.cs" />
     <Compile Include="Tests\XssPreventionAnalyzerTest.cs" />
     <Compile Include="Tests\CsrfTokenAnalyzerTest.cs" />
     <Compile Include="Tests\CsrfTokenCodeFixProviderTest.cs" />

--- a/RoslynSecurityGuard.Test/Tests/WeakPasswordValidatorAnalyzerTest.cs
+++ b/RoslynSecurityGuard.Test/Tests/WeakPasswordValidatorAnalyzerTest.cs
@@ -145,12 +145,6 @@ namespace RoslynSecurityGuard.Test.Tests
 					}
 				}";
 
-			var expected = new DiagnosticResult
-			{
-				Id = "SG0032",
-				Severity = DiagnosticSeverity.Warning
-			};
-
 			VerifyCSharpDiagnostic(test);
 		}
 
@@ -186,12 +180,6 @@ namespace RoslynSecurityGuard.Test.Tests
 						}
 					}
 				}";
-
-			var expected = new DiagnosticResult
-			{
-				Id = "SG0032",
-				Severity = DiagnosticSeverity.Warning
-			};
 
 			VerifyCSharpDiagnostic(test);
 		}

--- a/RoslynSecurityGuard.Test/Tests/WeakPasswordValidatorAnalyzerTest.cs
+++ b/RoslynSecurityGuard.Test/Tests/WeakPasswordValidatorAnalyzerTest.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TestHelper;
+using Microsoft.CodeAnalysis.Diagnostics;
+using RoslynSecurityGuard.Analyzers;
+using Microsoft.CodeAnalysis;
+using System.Web.Mvc;
+using Microsoft.AspNet.Identity;
+
+namespace RoslynSecurityGuard.Test.Tests
+{
+	[TestClass]
+	public class WeakPasswordValidatorAnalyzerTest : DiagnosticVerifier
+	{
+		protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+		{
+			return new[] { new WeakPasswordValidatorAnalyzer() };
+		}
+
+		protected override IEnumerable<MetadataReference> GetAdditionnalReferences()
+		{
+			return new[] { MetadataReference.CreateFromFile(typeof(Controller).Assembly.Location),
+				MetadataReference.CreateFromFile(typeof(System.Linq.Enumerable).Assembly.Location),
+				MetadataReference.CreateFromFile(typeof(PasswordValidator).Assembly.Location) };
+		}
+
+		[TestMethod]
+		public void PasswordValidatorDeclarationTooShort()
+		{
+			var test = @"
+				using Microsoft.AspNet.Identity;
+				using System.Web.Mvc;
+
+				namespace WebApplicationSandbox.Controllers
+				{
+					public class HomeController : Controller
+					{
+						public ActionResult Index()
+						{
+							PasswordValidator pwdv = new PasswordValidator
+							{
+								RequiredLength = 7,
+								RequireNonLetterOrDigit = true,
+								RequireDigit = true,
+								RequireLowercase = true,
+								RequireUppercase = true,
+							};
+
+							return View();
+						}
+					}
+				}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = "SG0032",
+				Severity = DiagnosticSeverity.Warning
+			};
+
+			VerifyCSharpDiagnostic(test, expected);
+		}
+
+		[TestMethod]
+		public void PasswordValidatorTooShort()
+		{
+			var test = @"
+				using Microsoft.AspNet.Identity;
+				using System.Web.Mvc;
+
+				namespace WebApplicationSandbox.Controllers
+				{
+					public class HomeController : Controller
+					{
+						public ActionResult Index()
+						{
+							PasswordValidator pwdv = new PasswordValidator
+							{
+				
+							};
+
+							pwdv.RequiredLength = 6;
+
+							return View();
+						}
+					}
+				}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = "SG0032",
+				Severity = DiagnosticSeverity.Warning
+			};
+
+			VerifyCSharpDiagnostic(test, expected);
+		}
+	}
+}
+
+
+

--- a/RoslynSecurityGuard.Test/Tests/WeakPasswordValidatorAnalyzerTest.cs
+++ b/RoslynSecurityGuard.Test/Tests/WeakPasswordValidatorAnalyzerTest.cs
@@ -97,6 +97,80 @@ namespace RoslynSecurityGuard.Test.Tests
 
 			VerifyCSharpDiagnostic(test, expected);
 		}
+
+		[TestMethod]
+		public void PasswordValidatorDeclarationOK()
+		{
+			var test = @"
+				using Microsoft.AspNet.Identity;
+				using System.Web.Mvc;
+
+				namespace WebApplicationSandbox.Controllers
+				{
+					public class HomeController : Controller
+					{
+						public ActionResult Index()
+						{
+							PasswordValidator pwdv = new PasswordValidator
+							{
+								RequiredLength = 10,
+								RequireNonLetterOrDigit = true,
+								RequireDigit = true,
+								RequireLowercase = true,
+								RequireUppercase = true,
+							};
+
+							return View();
+						}
+					}
+				}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = "SG0032",
+				Severity = DiagnosticSeverity.Warning
+			};
+
+			VerifyCSharpDiagnostic(test);
+		}
+
+		[TestMethod]
+		public void PasswordValidatorDeclarationWithVariable()
+		{
+			var test = @"
+				using Microsoft.AspNet.Identity;
+				using System.Web.Mvc;
+
+				namespace WebApplicationSandbox.Controllers
+				{
+					public class HomeController : Controller
+					{
+						public ActionResult Index()
+						{
+							int reqLen = 10;
+
+							PasswordValidator pwdv = new PasswordValidator
+							{
+								RequiredLength = reqLen,
+								RequireNonLetterOrDigit = true,
+								RequireDigit = true,
+								RequireLowercase = true,
+								RequireUppercase = true,
+							};
+
+							return View();
+						}
+					}
+				}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = "SG0032",
+				Severity = DiagnosticSeverity.Warning
+			};
+
+			VerifyCSharpDiagnostic(test);
+		}
 	}
 }
 

--- a/RoslynSecurityGuard.Test/Tests/WeakPasswordValidatorAnalyzerTest.cs
+++ b/RoslynSecurityGuard.Test/Tests/WeakPasswordValidatorAnalyzerTest.cs
@@ -13,14 +13,25 @@ using Microsoft.AspNet.Identity;
 
 namespace RoslynSecurityGuard.Test.Tests
 {
+	/// <summary>
+	/// Class used to test the validations on the PasswordValidator.
+	/// </summary>
 	[TestClass]
 	public class WeakPasswordValidatorAnalyzerTest : DiagnosticVerifier
 	{
+		/// <summary>
+		/// Sets which analyzers are needed for the tests.
+		/// </summary>
+		/// <returns>Array containing the different analyzers required for the tests.</returns>
 		protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
 		{
 			return new[] { new WeakPasswordValidatorAnalyzer() };
 		}
 
+		/// <summary>
+		/// Indicates which references are needed to compile the code.
+		/// </summary>
+		/// <returns>Array containing the different references needed for the code to compile.</returns>
 		protected override IEnumerable<MetadataReference> GetAdditionnalReferences()
 		{
 			return new[] { MetadataReference.CreateFromFile(typeof(Controller).Assembly.Location),
@@ -28,8 +39,11 @@ namespace RoslynSecurityGuard.Test.Tests
 				MetadataReference.CreateFromFile(typeof(PasswordValidator).Assembly.Location) };
 		}
 
+		/// <summary>
+		/// Test case where the RequiredLength field is too small inside the declaration.
+		/// </summary>
 		[TestMethod]
-		public void PasswordValidatorDeclarationTooShort()
+		public void PasswordValidatorDeclarationTooSmall()
 		{
 			var test = @"
 				using Microsoft.AspNet.Identity;
@@ -43,7 +57,7 @@ namespace RoslynSecurityGuard.Test.Tests
 						{
 							PasswordValidator pwdv = new PasswordValidator
 							{
-								RequiredLength = 7,
+								RequiredLength = " + (Constants.PasswordValidatorRequiredLength - 1) + @",
 								RequireNonLetterOrDigit = true,
 								RequireDigit = true,
 								RequireLowercase = true,
@@ -64,6 +78,9 @@ namespace RoslynSecurityGuard.Test.Tests
 			VerifyCSharpDiagnostic(test, expected);
 		}
 
+		/// <summary>
+		/// Test case where the RequiredLength field is too small but the value is affected outside of the declaration.
+		/// </summary>
 		[TestMethod]
 		public void PasswordValidatorTooShort()
 		{
@@ -82,7 +99,7 @@ namespace RoslynSecurityGuard.Test.Tests
 				
 							};
 
-							pwdv.RequiredLength = 6;
+							pwdv.RequiredLength = " + (Constants.PasswordValidatorRequiredLength - 1) + @";
 
 							return View();
 						}
@@ -98,6 +115,9 @@ namespace RoslynSecurityGuard.Test.Tests
 			VerifyCSharpDiagnostic(test, expected);
 		}
 
+		/// <summary>
+		/// Test case where the RequiredLength field has an accepted value.
+		/// </summary>
 		[TestMethod]
 		public void PasswordValidatorDeclarationOK()
 		{
@@ -113,7 +133,7 @@ namespace RoslynSecurityGuard.Test.Tests
 						{
 							PasswordValidator pwdv = new PasswordValidator
 							{
-								RequiredLength = 10,
+								RequiredLength = " + (Constants.PasswordValidatorRequiredLength + 1) + @",
 								RequireNonLetterOrDigit = true,
 								RequireDigit = true,
 								RequireLowercase = true,
@@ -134,6 +154,10 @@ namespace RoslynSecurityGuard.Test.Tests
 			VerifyCSharpDiagnostic(test);
 		}
 
+		/// <summary>
+		/// Test case where the RequiredLength field's value is set by a variable.
+		/// However the value of the variable is not tested.
+		/// </summary>
 		[TestMethod]
 		public void PasswordValidatorDeclarationWithVariable()
 		{
@@ -147,7 +171,7 @@ namespace RoslynSecurityGuard.Test.Tests
 					{
 						public ActionResult Index()
 						{
-							int reqLen = 10;
+							int reqLen = " + Constants.PasswordValidatorRequiredLength + @";
 
 							PasswordValidator pwdv = new PasswordValidator
 							{

--- a/RoslynSecurityGuard.Test/packages.config
+++ b/RoslynSecurityGuard.Test/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net452" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net452" />

--- a/RoslynSecurityGuard.Vsix/RoslynSecurityGuard.Vsix.csproj
+++ b/RoslynSecurityGuard.Vsix/RoslynSecurityGuard.Vsix.csproj
@@ -52,6 +52,7 @@
     <StartArguments>/rootsuffix Roslyn</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/RoslynSecurityGuard.Vsix/packages.config
+++ b/RoslynSecurityGuard.Vsix/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net452" />
+</packages>

--- a/RoslynSecurityGuard.Vsix/packages.config
+++ b/RoslynSecurityGuard.Vsix/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net452" />
+
 </packages>

--- a/RoslynSecurityGuard/Analyzers/WeakPasswordValidatorAnalyzer.cs
+++ b/RoslynSecurityGuard/Analyzers/WeakPasswordValidatorAnalyzer.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using RoslynSecurityGuard.Analyzers.Locale;
+using RoslynSecurityGuard.Analyzers.Taint;
+using RoslynSecurityGuard.Analyzers.Utils;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RoslynSecurityGuard.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class WeakPasswordValidatorAnalyzer : DiagnosticAnalyzer
+	{
+		private static DiagnosticDescriptor RulePasswordLength = LocaleUtil.GetDescriptor("SG0032");
+		private static DiagnosticDescriptor RulePasswordValidators = LocaleUtil.GetDescriptor("SG0033");
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(RulePasswordLength, RulePasswordValidators);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.RegisterSyntaxNodeAction(VisitAssignment, SyntaxKind.SimpleAssignmentExpression, SyntaxKind.VariableDeclaration);
+		}
+		
+		private static void VisitAssignment(SyntaxNodeAnalysisContext ctx)
+		{
+			AssignmentExpressionSyntax node = ctx.Node as AssignmentExpressionSyntax;
+
+			var symbol = ctx.SemanticModel.GetSymbolInfo(node.Left).Symbol;
+
+			var content = node.Right.GetText().ToString();
+
+			if (AnalyzerUtil.SymbolMatch(symbol, name: "RequiredLength") && content != String.Empty && Convert.ToInt32(content) < 8)
+			{
+				int numericValue;
+				if (!(int.TryParse(node.Right.GetText().ToString(), out numericValue) && numericValue > 8))
+				{
+					var diagnostic = Diagnostic.Create(RulePasswordLength, node.GetLocation());
+					ctx.ReportDiagnostic(diagnostic);
+				}
+			}
+		}
+	// //
+	}
+}

--- a/RoslynSecurityGuard/Analyzers/WeakPasswordValidatorAnalyzer.cs
+++ b/RoslynSecurityGuard/Analyzers/WeakPasswordValidatorAnalyzer.cs
@@ -38,7 +38,7 @@ namespace RoslynSecurityGuard.Analyzers
 			if (AnalyzerUtil.SymbolMatch(symbol, type: "PasswordValidator", name: "RequiredLength") && content != String.Empty)
 			{
 				int numericValue;
-				if (int.TryParse(node.Right.GetText().ToString(), out numericValue) && numericValue < 8)
+				if (int.TryParse(node.Right.GetText().ToString(), out numericValue) && numericValue < Constants.PasswordValidatorRequiredLength)
 				{
 					var diagnostic = Diagnostic.Create(RulePasswordLength, node.GetLocation());
 					ctx.ReportDiagnostic(diagnostic);

--- a/RoslynSecurityGuard/Analyzers/WeakPasswordValidatorAnalyzer.cs
+++ b/RoslynSecurityGuard/Analyzers/WeakPasswordValidatorAnalyzer.cs
@@ -24,7 +24,7 @@ namespace RoslynSecurityGuard.Analyzers
 
 		public override void Initialize(AnalysisContext context)
 		{
-			context.RegisterSyntaxNodeAction(VisitAssignment, SyntaxKind.SimpleAssignmentExpression, SyntaxKind.VariableDeclaration);
+			context.RegisterSyntaxNodeAction(VisitAssignment, SyntaxKind.SimpleAssignmentExpression);
 		}
 		
 		private static void VisitAssignment(SyntaxNodeAnalysisContext ctx)
@@ -35,10 +35,10 @@ namespace RoslynSecurityGuard.Analyzers
 
 			var content = node.Right.GetText().ToString();
 
-			if (AnalyzerUtil.SymbolMatch(symbol, name: "RequiredLength") && content != String.Empty && Convert.ToInt32(content) < 8)
+			if (AnalyzerUtil.SymbolMatch(symbol, type: "PasswordValidator", name: "RequiredLength") && content != String.Empty)
 			{
 				int numericValue;
-				if (!(int.TryParse(node.Right.GetText().ToString(), out numericValue) && numericValue > 8))
+				if (int.TryParse(node.Right.GetText().ToString(), out numericValue) && numericValue < 8)
 				{
 					var diagnostic = Diagnostic.Create(RulePasswordLength, node.GetLocation());
 					ctx.ReportDiagnostic(diagnostic);

--- a/RoslynSecurityGuard/Config/Messages.yml
+++ b/RoslynSecurityGuard/Config/Messages.yml
@@ -165,3 +165,14 @@ SG0029:
   class: XssPreventionAnalyzer
   title: Potential XSS vulnerability
   description: The endpoint returns a variable from the client input that has not been encoded.
+
+#Password Validator
+SG0032:
+    class: WeakPasswordValidatorAnalyzer
+    title: The RequiredLength property of PasswordValidator is too small.
+    description: The minimal length of a password is recommended to be set at least to 8.
+
+SG0033:
+    class: WeakPasswordValidatorAnalyzer
+    title: Not enough properties set in PasswordValidator
+    description: "PasswordValidator should have at least two requirements for better security (RequiredLength, RequireDigit, RequireLowercase, RequireUppercase and/or RequireNonLetterOrDigit)."

--- a/RoslynSecurityGuard/Constants.cs
+++ b/RoslynSecurityGuard/Constants.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RoslynSecurityGuard
+{
+	/// <summary>
+	/// This class is used to allow easier configuration of different parameters through the program.
+	/// </summary>
+	public static class Constants
+	{
+		// PasswordValidator
+		public const int PasswordValidatorRequiredLength = 8;
+	}
+}

--- a/RoslynSecurityGuard/RoslynSecurityGuard.csproj
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Analyzers\WeakCipherAnalyzer.cs" />
     <Compile Include="Analyzers\WeakCipherModeAnalyzer.cs" />
     <Compile Include="Analyzers\WeakHashingAnalyzer.cs" />
+    <Compile Include="Analyzers\WeakPasswordValidatorAnalyzer.cs" />
     <Compile Include="Analyzers\WeakRandomAnalyzer.cs" />
     <Compile Include="Analyzers\WebConfigAnalyzer.cs" />
     <Compile Include="Analyzers\XxeAnalyzer.cs" />

--- a/RoslynSecurityGuard/RoslynSecurityGuard.csproj
+++ b/RoslynSecurityGuard/RoslynSecurityGuard.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Analyzers\XxeAnalyzer.cs" />
     <Compile Include="CodeFixes\CsrfTokenCodeFixProvider.cs" />
     <Compile Include="CodeFixes\InsecureCookieCodeFixProvider.cs" />
+    <Compile Include="Constants.cs" />
     <Compile Include="Empty.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>


### PR DESCRIPTION
Added a validation to the PasswordValidator's RequiredLength property so that it is at least composed of 8 characters with tests.