### PR TITLE
Roslyn analyzers should be dev dependencies

### DIFF
--- a/RoslynSecurityGuard/Diagnostic.nuspec
+++ b/RoslynSecurityGuard/Diagnostic.nuspec
@@ -14,6 +14,7 @@
     <releaseNotes>This release introduce improved taint analysis. It also brings new code fixes.</releaseNotes>
     <copyright>Copyright Philippe Arteau</copyright>
     <tags>security,vulnerability,guard,owasp,injection,xss,csrf</tags>
+    <developmentDependency>true</developmentDependency>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>


### PR DESCRIPTION
Marking the package as a development dependency will inform NuGet that projects using the Roslyn analyzers shouldn't actually include the analyzer itself as a dependency for runtime.

References:
- [.nuspec file reference](https://docs.microsoft.com/en-us/nuget/schema/nuspec)
- [.nuspec used by StyleCop](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.nuspec#L16)
- [Template .nuspec for all Microsoft Roslyn analyzers](https://github.com/dotnet/roslyn-analyzers/blob/af8c297b65db728debfda84555a515298a3ee9ab/tools/AnalyzerCodeGenerator/template/src/REPLACE.ME/Core/REPLACE.ME.Analyzers.nuspec#L23)