### PR TITLE
generic parameter may have a default value that is null

### DIFF
--- a/RoslynSecurityGuard/Analyzers/Taint/MethodBehaviorRepository.cs
+++ b/RoslynSecurityGuard/Analyzers/Taint/MethodBehaviorRepository.cs
@@ -209,7 +209,7 @@ namespace RoslynSecurityGuard.Analyzers.Taint
                 result += parameterTypeString;
                 // result += " " + parameter.Name;
 
-                if (parameter.HasExplicitDefaultValue)
+                if (parameter.HasExplicitDefaultValue && parameter.ExplicitDefaultValue != null)
                     result += " = " + parameter.ExplicitDefaultValue.ToString();                
             }
 


### PR DESCRIPTION
Do not call ToString() on the default value of a generic parameter if it is null. I believe this is related to #65 and #67