### PR TITLE
Fix WeakCipherModeAnalyzer

### DIFF
--- a/RoslynSecurityGuard.Test/Tests/WeakCipherModeAnalyzerTest.cs
+++ b/RoslynSecurityGuard.Test/Tests/WeakCipherModeAnalyzerTest.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RoslynSecurityGuard.Analyzers;
@@ -77,8 +77,8 @@ End Class
 
             };
 
-            await VerifyCSharpDiagnostic(cSharpTest);
-            await VerifyVisualBasicDiagnostic(visualBasicTest);
+            await VerifyCSharpDiagnostic(cSharpTest, expected);
+            await VerifyVisualBasicDiagnostic(visualBasicTest, expected);
         }
 
         [TestMethod]
@@ -133,8 +133,15 @@ Class WeakCipherMode
     End Function
 End Class
 ";
-            await VerifyCSharpDiagnostic(cSharpTest);
-            await VerifyVisualBasicDiagnostic(visualBasicTest);
+            var expected = new DiagnosticResult
+            {
+                Id = "SG0013",
+                Severity = DiagnosticSeverity.Warning,
+
+            };
+
+            await VerifyCSharpDiagnostic(cSharpTest, expected);
+            await VerifyVisualBasicDiagnostic(visualBasicTest, expected);
         }
 
         [TestMethod]
@@ -232,12 +239,12 @@ End Class
 ";
             var expected = new DiagnosticResult
             {
-                Id = "SG0014",
+                Id = "SG0011",
                 Severity = DiagnosticSeverity.Warning,
             };
 
-            await VerifyCSharpDiagnostic(cSharpTest);
-            await VerifyVisualBasicDiagnostic(visualBasicTest);
+            await VerifyCSharpDiagnostic(cSharpTest, expected );
+            await VerifyVisualBasicDiagnostic(visualBasicTest, expected);
         }
 
         //TODO: Add tests to trigger the analyzer. 

--- a/RoslynSecurityGuard/Analyzers/WeakCipherModeAnalyzer.cs
+++ b/RoslynSecurityGuard/Analyzers/WeakCipherModeAnalyzer.cs
@@ -30,8 +30,8 @@ namespace RoslynSecurityGuard.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxNodeAction(VisitSyntaxNode, CSharp.SyntaxKind.InvocationExpression);
-            context.RegisterSyntaxNodeAction(VisitSyntaxNode, VB.SyntaxKind.InvocationExpression);
+            context.RegisterSyntaxNodeAction(VisitSyntaxNode, CSharp.SyntaxKind.SimpleMemberAccessExpression );
+            context.RegisterSyntaxNodeAction(VisitSyntaxNode, VB.SyntaxKind.SimpleMemberAccessExpression);
         }
 
         private static void VisitSyntaxNode(SyntaxNodeAnalysisContext ctx)
@@ -40,13 +40,13 @@ namespace RoslynSecurityGuard.Analyzers
 
             if (ctx.Node.Language == LanguageNames.CSharp)
             {
-                node = ctx.Node as CSharpSyntax.MemberAccessExpressionSyntax;
-                expression = ((CSharpSyntax.InvocationExpressionSyntax)node)?.Expression;
+                node = ctx.Node as CSharpSyntax.MemberAccessExpressionSyntax  ;
+                expression = ((CSharpSyntax.MemberAccessExpressionSyntax)node)?.Expression;
             }
             else
             {
                 node = ctx.Node as VBSyntax.MemberAccessExpressionSyntax;
-                expression = ((VBSyntax.InvocationExpressionSyntax)node)?.Expression;
+                expression = ((VBSyntax.MemberAccessExpressionSyntax)node)?.Expression;
             }
            
             if (node != null)


### PR DESCRIPTION
Correct the RegisterSyntaxNodeAction syntax type and update the node and expression conversions accordingly.  Fixes #96 (which I didnt introduce :)
TODO: Fix unit tests for this, as they're not up to date (which is why this was missed).